### PR TITLE
fix(BatteryLevelIndicator): remove unused 'PropType' import

### DIFF
--- a/libs/vue/src/components/BatteryLevelIndicator/BatteryLevelIndicator.vue
+++ b/libs/vue/src/components/BatteryLevelIndicator/BatteryLevelIndicator.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+import { defineComponent,computed } from 'vue';
 
 export default defineComponent({
   name: 'BatteryLevelIndicator',


### PR DESCRIPTION
Removed the unused 'PropType' import from the BatteryLevelIndicator component to resolve the TS6133 error. 
This change cleans up the code and ensures no unnecessary imports remain in the project.