### PR TITLE
Fix(BrushTool): This fix resolves the import and Type errors in the BrushTool stories

### DIFF
--- a/libs/vue/src/components/BatteryLevelIndicator/BatteryLevelIndicator.vue
+++ b/libs/vue/src/components/BatteryLevelIndicator/BatteryLevelIndicator.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+import { defineComponent,computed } from 'vue';
 
 export default defineComponent({
   name: 'BatteryLevelIndicator',

--- a/libs/vue/src/components/BottomNavigationBar/BottomNavigationBar.vue
+++ b/libs/vue/src/components/BottomNavigationBar/BottomNavigationBar.vue
@@ -42,6 +42,7 @@ export default defineComponent({
     },
     onHover(item: NavItem) {
       // Logic for hover state can be added here
+      console.log(`${item.label} is hovered`);
     },
   },
 });

--- a/libs/vue/src/components/BreadcrumbWithDropdowns/BreadcrumbWithDropdowns.vue
+++ b/libs/vue/src/components/BreadcrumbWithDropdowns/BreadcrumbWithDropdowns.vue
@@ -6,7 +6,7 @@
           v-if="!crumb.dropdown" 
           :class="{ 'breadcrumb-link': crumb.link }"
           @click="crumb.link ? navigateTo(crumb.link) : null"
-          :aria-current="index === breadcrumbs.length - 1 ? 'page' : null"
+          :aria-current="index === breadcrumbs.length - 1 ? 'page' : undefined"
         >
           {{ crumb.name }}
         </span>

--- a/libs/vue/src/components/BrushTool/BrushTool.stories.ts
+++ b/libs/vue/src/components/BrushTool/BrushTool.stories.ts
@@ -1,5 +1,5 @@
 import BrushTool from './BrushTool.vue';
-import { Meta, Story } from '@storybook/vue3';
+import { Meta, StoryFn } from '@storybook/vue3';
 
 export default {
   title: 'component/Drawing/BrushTool',
@@ -7,7 +7,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   components: { BrushTool },
   setup() {
     return { args };


### PR DESCRIPTION
Replaced the `Story` import with `StoryFn` as that's the correct module to imported. 

This fix also resolves the `args` type error  as the `StoryFn` correctly uses the components types.