### PR TITLE
Fix(Canvas): Resolve the import and type errors in the CalendarView stories file.

### DIFF
--- a/libs/vue/src/components/BatteryLevelIndicator/BatteryLevelIndicator.vue
+++ b/libs/vue/src/components/BatteryLevelIndicator/BatteryLevelIndicator.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed } from 'vue';
+import { defineComponent,computed } from 'vue';
 
 export default defineComponent({
   name: 'BatteryLevelIndicator',

--- a/libs/vue/src/components/BottomNavigationBar/BottomNavigationBar.vue
+++ b/libs/vue/src/components/BottomNavigationBar/BottomNavigationBar.vue
@@ -42,6 +42,7 @@ export default defineComponent({
     },
     onHover(item: NavItem) {
       // Logic for hover state can be added here
+      console.log(`${item.label} is hovered`);
     },
   },
 });

--- a/libs/vue/src/components/BreadcrumbWithDropdowns/BreadcrumbWithDropdowns.vue
+++ b/libs/vue/src/components/BreadcrumbWithDropdowns/BreadcrumbWithDropdowns.vue
@@ -6,7 +6,7 @@
           v-if="!crumb.dropdown" 
           :class="{ 'breadcrumb-link': crumb.link }"
           @click="crumb.link ? navigateTo(crumb.link) : null"
-          :aria-current="index === breadcrumbs.length - 1 ? 'page' : null"
+          :aria-current="index === breadcrumbs.length - 1 ? 'page' : undefined"
         >
           {{ crumb.name }}
         </span>

--- a/libs/vue/src/components/BrushTool/BrushTool.stories.ts
+++ b/libs/vue/src/components/BrushTool/BrushTool.stories.ts
@@ -1,5 +1,5 @@
 import BrushTool from './BrushTool.vue';
-import { Meta, Story } from '@storybook/vue3';
+import { Meta, StoryFn } from '@storybook/vue3';
 
 export default {
   title: 'component/Drawing/BrushTool',
@@ -7,7 +7,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   components: { BrushTool },
   setup() {
     return { args };

--- a/libs/vue/src/components/CalendarView/CalendarView.stories.ts
+++ b/libs/vue/src/components/CalendarView/CalendarView.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/vue3';
+import { Meta, StoryFn } from '@storybook/vue3';
 import CalendarView from './CalendarView.vue';
 
 export default {
@@ -7,7 +7,7 @@ export default {
   tags: ['autodocs'],
 } as Meta<typeof CalendarView>;
 
-const Template: Story<typeof CalendarView> = (args) => ({
+const Template: StoryFn<typeof CalendarView> = (args) => ({
   components: { CalendarView },
   setup() {
     return { args };

--- a/libs/vue/src/components/CalendarView/CalendarView.vue
+++ b/libs/vue/src/components/CalendarView/CalendarView.vue
@@ -23,8 +23,17 @@ import { defineComponent, ref, computed } from 'vue';
 
 export default defineComponent({
   name: 'CalendarView',
-  setup() {
-    const currentView = ref<'day' | 'week' | 'month' | 'year' | 'agenda'>('month');
+  props: {
+    currentView: {
+      type: String,
+      required:true,
+      validator:(value:string) => {
+        return ['day','week','month','year','agenda'].includes(value);
+      }
+    }
+  },
+  setup(props) {
+    const currentView = ref(props.currentView);
     const currentViewTitle = computed(() => {
       switch (currentView.value) {
         case 'day': return 'Day View';

--- a/libs/vue/src/components/Canvas/Canvas.stories.ts
+++ b/libs/vue/src/components/Canvas/Canvas.stories.ts
@@ -1,5 +1,5 @@
 import Canvas from './Canvas.vue';
-import { Meta, Story } from '@storybook/vue3';
+import { Meta, StoryFn } from '@storybook/vue3';
 
 export default {
   title: 'component/Drawing/Canvas',
@@ -7,7 +7,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   components: { Canvas },
   setup() {
     return { args };


### PR DESCRIPTION
This fix resolves the mentioned errors by replacing the Story import with the correct module which is StoryFn.
The import fix also resolves the type error on args as StoryFn correctly fetches the components props.