### PR TITLE
fix(CardbasedList.vue): Resolve cannot find name error:

### DIFF
--- a/libs/vue/src/components/CardbasedList/CardbasedList.vue
+++ b/libs/vue/src/components/CardbasedList/CardbasedList.vue
@@ -35,12 +35,12 @@ export default defineComponent({
       required: true,
     },
   },
-  setup() {
+  setup(props) {
     const hoveredIndex = ref<number | null>(null);
     const selectedIndex = ref<number | null>(null);
 
     const selectCard = (index: number) => {
-      if (!cards[index].disabled) {
+      if (props.cards[index].disabled) {
         selectedIndex.value = index;
       }
     };


### PR DESCRIPTION
Passed the `props`  of the component to the setup in order to access the cards array.