### PR TITLE
Fix(Checkbox): Fix TypeScript errors for the Storybook and Component files.

### DIFF
--- a/libs/vue/src/components/Checkbox/Checkbox.stories.ts
+++ b/libs/vue/src/components/Checkbox/Checkbox.stories.ts
@@ -1,4 +1,5 @@
 import Checkbox from './Checkbox.vue';
+import { Meta, StoryFn } from '@storybook/vue3';
 
 export default {
   component: Checkbox,
@@ -12,9 +13,9 @@ export default {
       control: { type: 'boolean' },
     },
   },
-};
+} as Meta;
 
-const Template = (args) => ({
+const Template:StoryFn = (args) => ({
   components: { Checkbox },
   setup() {
     return { args };

--- a/libs/vue/src/components/Checkbox/Checkbox.vue
+++ b/libs/vue/src/components/Checkbox/Checkbox.vue
@@ -4,9 +4,9 @@
       type="checkbox" 
       :checked="checked" 
       :disabled="disabled" 
-      @change="$emit('update:checked', $event.target.checked)" 
-      :aria-checked="checked.toString()" 
-      :aria-disabled="disabled.toString()"
+      @change="$emit('update:checked', ($event.target as HTMLInputElement).checked)" 
+      :aria-checked="checked" 
+      :aria-disabled="disabled"
     />
     <label :class="{ 'checkbox--disabled': disabled }">
       <slot />


### PR DESCRIPTION
Updated the Checkbox storybook file to include `Meta` and `StoryFn` types from `@storybook/vue3`. This resolves TypeScript errors and ensures proper type-checking for Storybook components.

- Cast event target to HTMLInputElement to access 'checked' property
- Ensure aria-checked and aria-disabled attributes are correctly bound
