### PR TITLE
fix(Chips.vue): Resolve `aria-pressed` value Typescript error.

### DIFF
--- a/libs/vue/src/components/Chips/Chips.vue
+++ b/libs/vue/src/components/Chips/Chips.vue
@@ -8,7 +8,7 @@
       @click="toggleSelect(index)"
       role="listitem"
       tabindex="0"
-      aria-pressed="chip.selected"
+      :aria-pressed="chip.selected"
     >
       <span>{{ chip.label }}</span>
       <button


### PR DESCRIPTION
Correctly bound the aria-pressed attribute the `chip.selected` value.