### PR TITLE
fix(ColorPicker.stories.ts): Resolve TypeScript errors in the Color Picker Story File

### DIFF
--- a/libs/vue/src/components/ColorPicker/ColorPicker.stories.ts
+++ b/libs/vue/src/components/ColorPicker/ColorPicker.stories.ts
@@ -1,5 +1,5 @@
 import ColorPicker from './ColorPicker.vue';
-import { Meta, Story } from '@storybook/vue3';
+import { Meta, StoryFn } from '@storybook/vue3';
 
 export default {
   title: 'component/Drawing/ColorPicker',
@@ -7,7 +7,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   components: { ColorPicker },
   setup() {
     return { args };


### PR DESCRIPTION
Replaced the `Story` import from storybook with `StoryFn` as thats the required module.

This fix also resolves the type error for `args` as `StoryFn` uses the components types.