### PR TITLE
fix(DataFilterPanel.stories.ts): Resolve TypeScript type errors in DataFilterPanel StoryBook

### DIFF
--- a/libs/vue/src/components/DataFilterPanel/DataFilterPanel.stories.ts
+++ b/libs/vue/src/components/DataFilterPanel/DataFilterPanel.stories.ts
@@ -1,12 +1,13 @@
 import DataFilterPanel from './DataFilterPanel.vue';
+import { Meta, StoryFn} from '@storybook/vue3'
 
 export default {
   title: 'components/Data/DataFilterPanel',
   component: DataFilterPanel,
   tags: ['autodocs'],
-};
+} as Meta
 
-const Template = (args: any) => ({
+const Template:StoryFn = (args: any) => ({
   components: { DataFilterPanel },
   setup() {
     return { args };


### PR DESCRIPTION
TypeScript errors in the Captcha.stories.ts file were resolved by introducing Meta and StoryFn types from @storybook/vue3. This ensures that the Storybook configuration follows proper TypeScript conventions.