### PR TITLE
fix(DataImportDialog.stories.ts): Resolve TypeScript type errors in DataImportDialog storybook file.

### DIFF
--- a/libs/vue/src/components/DataImportDialog/DataImportDialog.stories.ts
+++ b/libs/vue/src/components/DataImportDialog/DataImportDialog.stories.ts
@@ -1,12 +1,13 @@
 import DataImportDialog from './DataImportDialog.vue';
+import {Meta,StoryFn} from '@storybook/vue3'
 
 export default {
   title: 'components/Data/DataImportDialog',
   component: DataImportDialog,
   tags: ['autodocs'],
-};
+} as Meta
 
-const Template = (args: any) => ({
+const Template:StoryFn = (args: any) => ({
   components: { DataImportDialog },
   setup() {
     return { args };


### PR DESCRIPTION
TypeScript errors in the Captcha.stories.ts file were resolved by introducing Meta and StoryFn types from @storybook/vue3. This ensures that the Storybook configuration follows proper TypeScript conventions.