### PR TITLE
fix(DeckofCards): Resolve TypeScript type errors. Resolve `cannot find name 'cards'` error: 

### DIFF
--- a/libs/vue/src/components/DeckOfCards/DeckOfCards.stories.ts
+++ b/libs/vue/src/components/DeckOfCards/DeckOfCards.stories.ts
@@ -1,16 +1,13 @@
 import DeckOfCards from './DeckOfCards.vue';
+import {Meta,StoryFn} from '@storybook/vue3'
 
 export default {
   title: 'component/Cards/DeckOfCards',
   component: DeckOfCards,
   tags: ['autodocs'],
-  argTypes: {
-    cards: { control: 'array' },
-    overlap: { control: 'number' },
-  },
-};
+} as Meta; 
 
-const Template = (args: any) => ({
+const Template:StoryFn = (args: any) => ({
   components: { DeckOfCards },
   setup() {
     return { args };

--- a/libs/vue/src/components/DeckOfCards/DeckOfCards.vue
+++ b/libs/vue/src/components/DeckOfCards/DeckOfCards.vue
@@ -32,7 +32,7 @@ export default defineComponent({
       default: 10,
     },
   },
-  setup() {
+  setup(props) {
     const draggedCardIndex = ref<number | null>(null);
 
     const onDragStart = (index: number) => {
@@ -41,8 +41,8 @@ export default defineComponent({
 
     const onDrop = (index: number) => {
       if (draggedCardIndex.value !== null && draggedCardIndex.value !== index) {
-        const [draggedCard] = cards.value.splice(draggedCardIndex.value, 1);
-        cards.value.splice(index, 0, draggedCard);
+        const [draggedCard] = props.cards.splice(draggedCardIndex.value, 1);
+        props.cards.splice(index, 0, draggedCard);
       }
       draggedCardIndex.value = null;
     };


### PR DESCRIPTION
- TypeScript errors in the DeckofCards.stories.ts file were resolved by introducing Meta and StoryFn types from @storybook/vue3. This ensures that the Storybook configuration follows proper TypeScript conventions.

- Updated the onDrop method to use props.cards instead of cards.value.