### PR TITLE
fix(DropDownMenu.stories.ts): Resolve the click method was not found error.

### DIFF
--- a/libs/vue/src/components/DropdownMenu/DropdownMenu.stories.ts
+++ b/libs/vue/src/components/DropdownMenu/DropdownMenu.stories.ts
@@ -33,7 +33,7 @@ Expanded.args = {
   ],
 };
 Expanded.play = async ({ canvasElement }) => {
-  const button = canvasElement.querySelector('.dropdown-toggle');
+  const button:HTMLElement = canvasElement.querySelector('.dropdown-toggle') as HTMLElement;
   if (button) {
     button.click();
   }


### PR DESCRIPTION
- Resolved by casting the button element to a `HTMLElement` as the click method is not defined in `Element`