### PR TITLE
fix(EmbeddedMediaIframe.vue): Resolve TypeScript type error on aria attribute.

### DIFF
--- a/libs/vue/src/components/EmbeddedMediaIframe/EmbeddedMediaIframe.vue
+++ b/libs/vue/src/components/EmbeddedMediaIframe/EmbeddedMediaIframe.vue
@@ -5,7 +5,7 @@
       :src="src"
       frameborder="0"
       allowfullscreen
-      aria-busy="isBuffering"
+      :aria-busy="isBuffering"
       @load="handleLoad"
     ></iframe>
     <button v-if="!isFullscreen" @click="toggleFullscreen" aria-label="Enter fullscreen" class="fullscreen-btn">⤢</button>


### PR DESCRIPTION
Correctly bind `isBuffering` value to the `aria-busy` attribute.