### PR TITLE
fix:(EmojiReactionPoll): Simplify Storybook configuration and correct StoryFn import

### DIFF
--- a/libs/vue/src/components/EmojiReactionPoll/EmojiReactionPoll.stories.ts
+++ b/libs/vue/src/components/EmojiReactionPoll/EmojiReactionPoll.stories.ts
@@ -1,20 +1,13 @@
-import { Meta, Story } from '@storybook/vue3';
+import { Meta, StoryFn } from '@storybook/vue3';
 import EmojiReactionPoll from './EmojiReactionPoll.vue';
 
 export default {
   title: 'component/Polls/EmojiReactionPoll',
   component: EmojiReactionPoll,
   tags: ['autodocs'],
-  argTypes: {
-    question: { control: 'text' },
-    emojis: { control: 'array' },
-    initialSelection: { control: 'number' },
-    isDisabled: { control: 'boolean' },
-    showResults: { control: 'boolean' },
-  },
 } as Meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   components: { EmojiReactionPoll },
   setup() {
     return { args };


### PR DESCRIPTION
- Removed argTypes from EmojiReactionPoll stories to allow Meta to handle prop types automatically.
- Fixed incorrect import of StoryFn module to ensure proper functionality.