### PR TITLE
fix: Remove unused import to resolve compilation error

### DIFF
--- a/libs/vue/src/components/EventDetailsDialog/EventDetailsDialog.vue
+++ b/libs/vue/src/components/EventDetailsDialog/EventDetailsDialog.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, PropType } from 'vue';
+import { defineComponent,PropType } from 'vue';
 
 interface EventDetails {
   title: string;


### PR DESCRIPTION
- Deleted an the `ref` import that was causing a compilation error, improving code cleanliness and preventing unnecessary warnings.