### PR TITLE
fix(ExpendableList.stories) : Resolve TypeScript type error for wrong…

### DIFF
--- a/libs/vue/src/components/ExpandableList/ExpandableList.stories.ts
+++ b/libs/vue/src/components/ExpandableList/ExpandableList.stories.ts
@@ -6,7 +6,7 @@ export default {
   component: ExpandableList,
   tags: ['autodocs'],
   argTypes: {
-    items: { control: 'array' },
+    items: { control: 'object' },
   },
 } as Meta<typeof ExpandableList>;
 


### PR DESCRIPTION
… control type used.

- Used the correct control type for the items argument to resolve the type error.