### PR TITLE
fix(FavoritesList.stories) : Resolve TypeScript type error for wrong control type used.

### DIFF
--- a/libs/vue/src/components/FavoritesList/FavoritesList.stories.ts
+++ b/libs/vue/src/components/FavoritesList/FavoritesList.stories.ts
@@ -6,7 +6,7 @@ export default {
   component: FavoritesList,
   tags: ['autodocs'],
   argTypes: {
-    items: { control: 'array' },
+    items: { control: 'object' },
   },
 } as Meta<typeof FavoritesList>;
 


### PR DESCRIPTION
- Used the correct control type for the items argument to resolve the type error.