### PR TITLE
fix(FieldEditableDataTable): Resolve TypeScript type errors.

### DIFF
--- a/libs/vue/src/components/FieldEditableDataTable/FieldEditableDataTable.stories.ts
+++ b/libs/vue/src/components/FieldEditableDataTable/FieldEditableDataTable.stories.ts
@@ -1,12 +1,13 @@
 import FieldEditableDataTable from './FieldEditableDataTable.vue';
+import {Meta,StoryFn} from '@storybook/vue3';
 
 export default {
   title: 'components/Data/FieldEditableDataTable',
   component: FieldEditableDataTable,
   tags: ['autodocs'],
-};
+} as Meta;
 
-const Template = (args: any) => ({
+const Template:StoryFn = (args: any) => ({
   components: { FieldEditableDataTable },
   setup() {
     return { args };

--- a/libs/vue/src/components/FieldEditableDataTable/FieldEditableDataTable.vue
+++ b/libs/vue/src/components/FieldEditableDataTable/FieldEditableDataTable.vue
@@ -58,7 +58,7 @@ export default defineComponent({
 
 <template>
   <div class="field-editable-data-table" role="table">
-    <div role="row" v-for="(row, index) in data" :key="row.id" class="table-row">
+    <div role="row" v-for="(row) in data" :key="row.id" class="table-row">
       <div role="cell" class="table-cell" v-for="(value, key) in row" :key="key">
         <template v-if="editingField && editingField.rowId === row.id && editingField.field === key">
           <textarea v-if="key === 'description'" v-model="fieldValues[key]" aria-label="Edit description"></textarea>
@@ -67,7 +67,7 @@ export default defineComponent({
           <button @click="discardChanges">Cancel</button>
         </template>
         <template v-else>
-          <span @click="editField(row.id, key)" class="editable-field">{{ value }}</span>
+          <span @click="editField(row.id, key.toString())" class="editable-field">{{ value }}</span>
         </template>
       </div>
     </div>


### PR DESCRIPTION
fix(FieldEditableDataTable.vue): Fix type error in editField argument by converting key to string
fix(FieldEditableDataTable.stories.ts) :Resolved type errors by introducing the Meta and StoryFn modules for better type handling.
