### PR TITLE
fix(FileInputWithPreview): Resolve TypeScript type errors and incorrect value binding to aria attribute.

### DIFF
--- a/libs/vue/src/components/FileInputWithPreview/FileInputWithPreview.stories.ts
+++ b/libs/vue/src/components/FileInputWithPreview/FileInputWithPreview.stories.ts
@@ -1,4 +1,5 @@
 import FileInputWithPreview from './FileInputWithPreview.vue';
+import {Meta,StoryFn} from '@storybook/vue3'
 
 export default {
   component: FileInputWithPreview,
@@ -9,9 +10,9 @@ export default {
       control: { type: 'boolean' },
     },
   },
-};
+} as Meta;
 
-const Template = (args) => ({
+const Template:StoryFn = (args) => ({
   components: { FileInputWithPreview },
   setup() {
     return { args };

--- a/libs/vue/src/components/FileInputWithPreview/FileInputWithPreview.vue
+++ b/libs/vue/src/components/FileInputWithPreview/FileInputWithPreview.vue
@@ -5,7 +5,7 @@
       :disabled="disabled" 
       @change="handleFileUpload" 
       aria-label="Upload File"
-      :aria-disabled="disabled.toString()"
+      :aria-disabled="disabled"
     />
     <div v-if="preview" class="preview-container">
       <img :src="preview" alt="File Preview" class="preview-image"/>


### PR DESCRIPTION
fix(FileInputWithPreview.stories.ts): Resolve TypeScript type errors : Introduce Meta and StoryFn modules for proper type handling
fix(FileInputWithPreview.vue): Resolve TypeScipt type error: Correctly bind the aria-disabled attribute to the correct value type of disabled.