### PR TITLE
Fix (GroupedList): Resolve unused variables and cast elements to the correct type. 

### DIFF
--- a/libs/vue/src/components/GroupedList/GroupedList.stories.ts
+++ b/libs/vue/src/components/GroupedList/GroupedList.stories.ts
@@ -33,7 +33,7 @@ GroupExpanded.args = {
   ...Default.args,
 };
 GroupExpanded.play = async ({ args, canvasElement }) => {
-  const headers = canvasElement.querySelectorAll('.group-header');
+  const headers = canvasElement.querySelectorAll('.group-header') as NodeListOf<HTMLElement>;
   headers.forEach(header => header.click());
 };
 
@@ -42,7 +42,7 @@ GroupCollapsed.args = {
   ...Default.args,
 };
 GroupCollapsed.play = async ({ args, canvasElement }) => {
-  const headers = canvasElement.querySelectorAll('.group-header');
+  const headers = canvasElement.querySelectorAll('.group-header') as NodeListOf<HTMLElement>;
   headers.forEach(header => header.click());
   headers.forEach(header => header.click());
 };
@@ -57,6 +57,6 @@ ItemSelected.args = {
   ...Default.args,
 };
 ItemSelected.play = async ({ args, canvasElement }) => {
-  const items = canvasElement.querySelectorAll('.list-item');
+  const items = canvasElement.querySelectorAll('.list-item') as NodeListOf<HTMLElement>;
   items[0].click();
 };

--- a/libs/vue/src/components/GroupedList/GroupedList.stories.ts
+++ b/libs/vue/src/components/GroupedList/GroupedList.stories.ts
@@ -32,7 +32,7 @@ export const GroupExpanded = Template.bind({});
 GroupExpanded.args = {
   ...Default.args,
 };
-GroupExpanded.play = async ({ args, canvasElement }) => {
+GroupExpanded.play = async ({ canvasElement }) => {
   const headers = canvasElement.querySelectorAll('.group-header') as NodeListOf<HTMLElement>;
   headers.forEach(header => header.click());
 };
@@ -41,7 +41,7 @@ export const GroupCollapsed = Template.bind({});
 GroupCollapsed.args = {
   ...Default.args,
 };
-GroupCollapsed.play = async ({ args, canvasElement }) => {
+GroupCollapsed.play = async ({ canvasElement }) => {
   const headers = canvasElement.querySelectorAll('.group-header') as NodeListOf<HTMLElement>;
   headers.forEach(header => header.click());
   headers.forEach(header => header.click());
@@ -56,7 +56,7 @@ export const ItemSelected = Template.bind({});
 ItemSelected.args = {
   ...Default.args,
 };
-ItemSelected.play = async ({ args, canvasElement }) => {
+ItemSelected.play = async ({ canvasElement }) => {
   const items = canvasElement.querySelectorAll('.list-item') as NodeListOf<HTMLElement>;
   items[0].click();
 };


### PR DESCRIPTION
fix(GroupedList.stories.ts): remove unused 'args' parameter from GroupExpanded.play function
fix(GroupedList.stories.ts): Resolve method not found error : - Resolve the error by casting the clicked elements to a HTMLElement.
