### PR TITLE
fix(FloatinActionButton.stories.tsx): Resolve TypeScript type error by adding prop in component file.

### DIFF
--- a/libs/vue/src/components/FlipCard/FlipCard.stories.ts
+++ b/libs/vue/src/components/FlipCard/FlipCard.stories.ts
@@ -1,4 +1,5 @@
 import FlipCard from './FlipCard.vue';
+import {Meta,StoryFn} from '@storybook/vue3'
 
 export default {
   title: 'component/Cards/FlipCard',
@@ -7,9 +8,9 @@ export default {
   argTypes: {
     disabled: { control: 'boolean' },
   },
-};
+} as Meta;
 
-const Template = (args) => ({
+const Template:StoryFn = (args) => ({
   components: { FlipCard },
   setup() {
     return { args };

--- a/libs/vue/src/components/FloatingActionButton/FloatingActionButton.vue
+++ b/libs/vue/src/components/FloatingActionButton/FloatingActionButton.vue
@@ -2,11 +2,11 @@
   <button
     class="floating-action-button"
     @click="toggleExpand"
-    :aria-expanded="isExpanded"
+    :aria-expanded="localIsExpanded"
   >
-    <span v-if="isExpanded" aria-hidden="true">✖</span>
+    <span v-if="localIsExpanded" aria-hidden="true">✖</span>
     <span v-else aria-hidden="true">+</span>
-    <span class="sr-only">{{ isExpanded ? 'Close menu' : 'Open menu' }}</span>
+    <span class="sr-only">{{ localIsExpanded ? 'Close menu' : 'Open menu' }}</span>
   </button>
 </template>
 
@@ -15,14 +15,20 @@ import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
   name: 'FloatingActionButton',
-  setup() {
-    const isExpanded = ref(false);
+  props: {
+    isExpanded: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props) {
+    const localIsExpanded = ref(props.isExpanded);
 
     const toggleExpand = () => {
-      isExpanded.value = !isExpanded.value;
+      localIsExpanded.value = !localIsExpanded.value;
     };
 
-    return { isExpanded, toggleExpand };
+    return { localIsExpanded, toggleExpand };
   },
 });
 </script>


### PR DESCRIPTION
- The Floating Button storybook is  accessing isExpanded prop which is not present as a prop in the vue file. Introducing the prop to the component resolved this error.