### PR TITLE
fix(ImageChoicePoll.stories.ts): Resolve TypeScript error.

### DIFF
--- a/libs/vue/src/components/ImageChoicePoll/ImageChoicePoll.stories.ts
+++ b/libs/vue/src/components/ImageChoicePoll/ImageChoicePoll.stories.ts
@@ -30,7 +30,7 @@ Default.args = {
     { image: 'link-to-image-2.jpg', alt: 'Image 2' },
     { image: 'link-to-image-3.jpg', alt: 'Image 3' }
   ],
-  initialValue: null,
+  initialValue: undefined,
   resultsVisible: false,
   disabled: false
 };


### PR DESCRIPTION
- `InitialValue` only takes number and undefined as values. Resolved by changing the value to undefined from null.