### PR TITLE
Fix(ImageSlider) : Resolve variable not used Errors and also TypeScript type Error

### DIFF
--- a/libs/vue/src/components/ImageSlider/ImageSlider.stories.ts
+++ b/libs/vue/src/components/ImageSlider/ImageSlider.stories.ts
@@ -6,7 +6,7 @@ export default {
   component: ImageSlider,
   tags: ['autodocs'],
   argTypes: {
-    images: { control: 'array' },
+    images: { control: 'object' },
   },
 } as Meta<typeof ImageSlider>;
 

--- a/libs/vue/src/components/ImageSlider/ImageSlider.vue
+++ b/libs/vue/src/components/ImageSlider/ImageSlider.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed } from 'vue';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
   name: 'ImageSlider',


### PR DESCRIPTION
fix(ImageSlider.vue): Resolve variable not used error :  Remove the `computed` import from vue as it is not used.

fix(ImageSlider.stories.ts): Resolve type error for the array control : Replace the array control with object for the images as it is not supported by StoryBook.
