### PR TITLE
Multi select list

### DIFF
--- a/libs/vue/src/components/MultiselectList/MultiselectList.stories.ts
+++ b/libs/vue/src/components/MultiselectList/MultiselectList.stories.ts
@@ -33,19 +33,23 @@ export const ItemSelected = Template.bind({});
 ItemSelected.args = {
   ...Default.args,
 };
-ItemSelected.play = async ({ args, canvasElement }) => {
-  const item = canvasElement.querySelector('.list-item:nth-child(1)');
-  item.click();
+ItemSelected.play = async ({ canvasElement }) => {
+  const item = canvasElement.querySelector('.list-item:nth-child(1)') as HTMLElement;
+  if(item){
+    item.click();
+  }
 };
 
 export const ItemDeselected = Template.bind({});
 ItemDeselected.args = {
   ...Default.args,
 };
-ItemDeselected.play = async ({ args, canvasElement }) => {
-  const item = canvasElement.querySelector('.list-item:nth-child(1)');
-  item.click();
-  item.click();
+ItemDeselected.play = async ({ canvasElement }) => {
+  const item = canvasElement.querySelector('.list-item:nth-child(1)') as HTMLElement;
+  if(item){
+    item.click();
+    item.click();
+  }
 };
 
 export const Disabled = Template.bind({});
@@ -61,7 +65,7 @@ export const Hover = Template.bind({});
 Hover.args = {
   ...Default.args,
 };
-Hover.play = async ({ args, canvasElement }) => {
-  const item = canvasElement.querySelector('.list-item:nth-child(1)');
+Hover.play = async ({ canvasElement }) => {
+  const item = canvasElement.querySelector('.list-item:nth-child(1)') as HTMLElement;
   item.dispatchEvent(new Event('mouseover'));
 };

--- a/libs/vue/src/components/MultiselectList/MultiselectList.vue
+++ b/libs/vue/src/components/MultiselectList/MultiselectList.vue
@@ -2,7 +2,7 @@
   <div class="multiselect-list" role="listbox" aria-multiselectable="true">
     <ul class="item-list" role="list" aria-label="Selectable Items">
       <li
-        v-for="(item, index) in items"
+        v-for="(item) in items"
         :key="item.value"
         :class="['list-item', { selected: selectedItems.includes(item.value), disabled: item.disabled }]"
         @click="toggleItemSelection(item)"


### PR DESCRIPTION
- Resolve the unused variable by removing the index variable on the li element as it was not used.

- Added null checks for the item element to resolve the items might be null error.

- Cast the item element as a HTMLELement to access the click method

- Remove the args argument passed on the play function to resolve the variable is not read error.