### PR TITLE
fix(PokerTimer.vue): update intervalId type to ReturnType<typeof setInterval>

### DIFF
--- a/libs/vue/src/components/PokerTimer/PokerTimer.vue
+++ b/libs/vue/src/components/PokerTimer/PokerTimer.vue
@@ -42,7 +42,7 @@ export default defineComponent({
       isPaused.value = !isPaused.value;
     };
 
-    let intervalId: number;
+    let intervalId: ReturnType<typeof setInterval>;
     onMounted(() => {
       intervalId = setInterval(tick, 1000);
     });


### PR DESCRIPTION
Changed the type of intervalId from number to ReturnType<typeof setInterval> to resolve TypeScript error regarding type assignment. This ensures compatibility with the return value of setInterval.