### PR TITLE
fix(Pagination.stories.ts): Resolve variable not used and null error.

### DIFF
--- a/libs/vue/src/components/Pagination/Pagination.stories.ts
+++ b/libs/vue/src/components/Pagination/Pagination.stories.ts
@@ -43,7 +43,9 @@ export const Hover = Template.bind({});
 Hover.args = {
   ...Default.args,
 };
-Hover.play = async ({ args, canvasElement }) => {
+Hover.play = async ({ canvasElement }) => {
   const item = canvasElement.querySelector('.pagination-item:nth-child(2)');
-  item.dispatchEvent(new Event('mouseover'));
+  if(item){
+    item.dispatchEvent(new Event('mouseover'));
+  }
 };


### PR DESCRIPTION
- Add a null check for the `item` html element.
- Remove the args argument passed to the play function as it was not used.