### PR TITLE
 fix(RichTextEditor.vue):Install type definitions for Quill to resolve module not found error Beta

### DIFF
--- a/libs/vue/package.json
+++ b/libs/vue/package.json
@@ -23,6 +23,7 @@
     "@storybook/test": "^8.3.5",
     "@storybook/vue3": "^8.3.5",
     "@storybook/vue3-vite": "^8.3.5",
+    "@types/quill": "^2.0.14",
     "@vitejs/plugin-vue": "^5.1.4",
     "storybook": "^8.3.5",
     "typescript": "^5.5.3",

--- a/libs/vue/src/components/RichTextEditor/RichTextEditor.stories.ts
+++ b/libs/vue/src/components/RichTextEditor/RichTextEditor.stories.ts
@@ -1,4 +1,5 @@
 import RichTextEditor from './RichTextEditor.vue';
+import {Meta,StoryFn} from '@storybook/vue3'
 
 export default {
   component: RichTextEditor,
@@ -7,9 +8,9 @@ export default {
   argTypes: {
     readonly: { control: { type: 'boolean' } },
   },
-};
+} as Meta<typeof RichTextEditor>
 
-const Template = (args) => ({
+const Template:StoryFn<typeof RichTextEditor> = (args) => ({
   components: { RichTextEditor },
   setup() {
     return { args };


### PR DESCRIPTION
fix(RichTextEditor.stories.ts): Resolve TypeScript Type errors. - Introduce Meta and StoryFn modules for proper type handling.