### PR TITLE
fix:(ScrollableList.stories.ts): Resolve null check and unused variable error.

### DIFF
--- a/libs/vue/src/components/ScrollableList/ScrollableList.stories.ts
+++ b/libs/vue/src/components/ScrollableList/ScrollableList.stories.ts
@@ -41,9 +41,11 @@ export const Hover = Template.bind({});
 Hover.args = {
   ...Default.args,
 };
-Hover.play = async ({ args, canvasElement }) => {
+Hover.play = async ({ canvasElement }) => {
   const item = canvasElement.querySelector('.scrollable-list-item:nth-child(2)');
-  item.dispatchEvent(new Event('mouseover'));
+  if(item){
+    item.dispatchEvent(new Event('mouseover'));
+  }
 };
 
 export const Disabled = Template.bind({});


### PR DESCRIPTION
- Add a null check for the `item` variable to resolve null check error.
- Remove args argument passed to the hover.play function as it was not being used.