### PR TITLE
fix(LiveStreamPlayer.vue): Resolve TypeScript type and unused variables errors.

### DIFF
--- a/libs/vue/src/components/LiveStreamPlayer/LiveStreamPlayer.vue
+++ b/libs/vue/src/components/LiveStreamPlayer/LiveStreamPlayer.vue
@@ -68,6 +68,10 @@ export default defineComponent({
       muted,
       buffering,
       toggleMute,
+      onPlay,
+      onPause,
+      onBuffering,
+      onVolumeChange,
     };
   },
 });


### PR DESCRIPTION
- Return the unused variables from setup in order for them to be accessible in the template.