### PR TITLE
fix(SortableList.stories.ts): Resolve null  and unused variable errors.

### DIFF
--- a/libs/vue/src/components/SortableList/SortableList.stories.ts
+++ b/libs/vue/src/components/SortableList/SortableList.stories.ts
@@ -35,9 +35,11 @@ export const Dragging = Template.bind({});
 Dragging.args = {
   ...Default.args,
 };
-Dragging.play = async ({ args, canvasElement }) => {
-  const item = canvasElement.querySelector('li');
-  item.dispatchEvent(new DragEvent('dragstart'));
+Dragging.play = async ({ canvasElement }) => {
+  const item = canvasElement.querySelector('li') as HTMLElement;
+  if(item){
+    item.dispatchEvent(new DragEvent('dragstart'));
+  }
 };
 
 export const Sorted = Template.bind({});


### PR DESCRIPTION
- Remove the arg argument pased to the `Dragging.play` as it was not used
- Add null check to the item
- Cast the item as a HTMLElement.