### PR TITLE
Fix:(SearchBar.vue) Update SearchBar component to use local reactive variable for focus state

### DIFF
--- a/libs/vue/src/components/SearchBar/SearchBar.vue
+++ b/libs/vue/src/components/SearchBar/SearchBar.vue
@@ -31,12 +31,13 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const isFocused = ref(props.isFocused)
     const handleFocus = () => {
-      props.isFocused = true;
+      isFocused.value = true;
     };
 
     const handleBlur = () => {
-      props.isFocused = false;
+    isFocused.value = false;
     };
 
     return { handleFocus, handleBlur };


### PR DESCRIPTION
- Changed the handleFocus and handleBlur methods to modify a local reactive variable instead of directly assigning to the read-only prop `isFocused`.