### PR TITLE
Fix: Update isFocused handling in setup to use ref.value

### DIFF
--- a/libs/vue/src/components/VisualCueForAccessibilityFocusIndicator/VisualCueForAccessibilityFocusIndicator.vue
+++ b/libs/vue/src/components/VisualCueForAccessibilityFocusIndicator/VisualCueForAccessibilityFocusIndicator.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent,ref } from 'vue';
 
 export default defineComponent({
   name: 'VisualCueForAccessibilityFocusIndicator',
@@ -20,12 +20,13 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const isFocused = ref(props.isFocused);
     const handleFocus = () => {
-      props.isFocused = true;
+      isFocused.value = true;
     };
 
     const handleBlur = () => {
-      props.isFocused = false;
+      isFocused.value = false;
     };
 
     return { handleFocus, handleBlur };


### PR DESCRIPTION
Resolved the error "isFocused cannot be changed as it is read-only" by correctly updating the isFocused state using isFocused.value instead of directly assigning to isFocused. This ensures proper reactivity in the component.