### PR TITLE
fix: update winningCards, PlayerCards,CommunityCards control type to 'object' in WinningHandDisplay stories

### DIFF
--- a/libs/vue/src/components/WinningHandDisplay/WinningHandDisplay.stories.ts
+++ b/libs/vue/src/components/WinningHandDisplay/WinningHandDisplay.stories.ts
@@ -9,9 +9,9 @@ export default {
     layout: 'centered',
   },
   argTypes: {
-    communityCards: { control: 'array' },
-    playerCards: { control: 'array' },
-    winningCards: { control: 'array' },
+    communityCards: { control: 'object' },
+    playerCards: { control: 'object' },
+    winningCards: { control: 'object' },
     isHidden: { control: 'boolean' },
   },
 } as Meta<typeof WinningHandDisplay>;


### PR DESCRIPTION
Changed the control type for winningCards from 'array' to 'object' to ensure compatibility with the expected type in the Storybook configuration.