### PR TITLE
fix(360-DegreeImageViewer.stories.ts): Resolve esport default storybook error.

### DIFF
--- a/libs/vue/src/components/360-DegreeImageViewer/360-DegreeImageViewer.stories.ts
+++ b/libs/vue/src/components/360-DegreeImageViewer/360-DegreeImageViewer.stories.ts
@@ -6,10 +6,10 @@ export default {
   component: DegreeImageViewer,
   tags: ['autodocs'],
   argTypes: {
-    images: { control: 'array' },
+    images: { control: 'object' },
     rotationSpeed: { control: 'number' },
   },
-} as unknown as Meta<typeof DegreeImageViewer>; // Cast to unknown first, then Meta
+} as Meta<typeof DegreeImageViewer>; // Cast to unknown first, then Meta
 
 
 const Template: StoryFn<typeof DegreeImageViewer> = (args) => ({


### PR DESCRIPTION
The default export was casted as unkown which produced and error when trying to access the storybook.

Removed the unkown cast and fixed the image control type from array to object.