### PR TITLE
Accordion - SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/Accordion/Accordion.stories.ts
+++ b/libs/sveltekit/src/components/Accordion/Accordion.stories.ts
@@ -1,5 +1,5 @@
 import Accordion from './Accordion.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryObj, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<Accordion> = {
   title: 'component/Lists/Accordion',
@@ -27,37 +27,38 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    isOpen: false,
-    title: 'Accordion Title',
-    content: 'Accordion content goes here.'
-  }
-};
+const Template:StoryFn = (args) => ({
+  Component: Accordion,
+  props:args,
+})
 
-export const Open: Story = {
-  args: {
-    isOpen: true,
-    title: 'Accordion Title',
-    content: 'Accordion content goes here.'
-  }
-};
+export const Default = Template.bind({});
+Default.args = {
+  isOpen:false,
+  title:'Accordion Title',
+  content:'Accordion content goes here.'
+}
 
-export const Closed: Story = {
-  args: {
-    isOpen: false,
-    title: 'Accordion Title',
-    content: 'Accordion content goes here.'
-  }
-};
+export const Open = Template.bind({});
+Open.args = {
+  isOpen:true,
+  title:'Accordion Title',
+  content:'Accordion content goes here.'
+}
 
-export const Hover: Story = {
-  args: {
-    isOpen: false,
-    title: 'Accordion Title',
-    content: 'Accordion content goes here.'
-  },
-  parameters: {
-    pseudo: { hover: true }
-  }
+export const Closed = Template.bind({});
+Closed.args = {
+  isOpen:false,
+  title:'Accordion Title',
+  content:'Accordion content goes here.'
+}
+
+export const Hover = Template.bind({});
+Hover.args = {
+  isOpen:false,
+  title: 'Accordion Title',
+  content: 'Accordion content goes here.'
 };
+Hover.parameters = {
+  pseudo:{hover:true}
+}

--- a/libs/sveltekit/src/components/Accordion/Accordion.stories.ts
+++ b/libs/sveltekit/src/components/Accordion/Accordion.stories.ts
@@ -1,5 +1,5 @@
 import Accordion from './Accordion.svelte';
-import type { Meta, StoryObj, StoryFn } from '@storybook/svelte';
+import type { Meta,StoryFn } from '@storybook/svelte';
 
 const meta: Meta<Accordion> = {
   title: 'component/Lists/Accordion',
@@ -24,8 +24,6 @@ const meta: Meta<Accordion> = {
 };
 
 export default meta;
-
-type Story = StoryObj<typeof meta>;
 
 const Template:StoryFn = (args) => ({
   Component: Accordion,

--- a/libs/sveltekit/src/components/Accordion/Accordion.svelte
+++ b/libs/sveltekit/src/components/Accordion/Accordion.svelte
@@ -18,7 +18,7 @@
     {title}
   </button>
   {#if isOpen}
-    <div id="accordion-content" class="accordion-content" tabindex="0">
+    <div id="accordion-content" class="accordion-content">
       {content}
     </div>
   {/if}


### PR DESCRIPTION
fix: Resolve TypeScript error for Accordion component props
- Updated the Accordion story file to correctly import the Accordion component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, the Accordion component can now be used in Storybook without type errors, and the props can be controlled as intended.


fix: Remove tabindex from accordion content div to improve accessibility
The tabindex attribute was removed from the accordion content div to address the accessibility warning: "A11y: noninteractive element cannot have nonnegative tabIndex value." This change ensures compliance with accessibility standards by preventing non-interactive elements from having a tabindex, thereby enhancing the overall user experience for keyboard navigation.