### PR TITLE
360-DegreeImageViewe - SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/360-DegreeImageViewer/360-DegreeImageViewer.stories.ts
+++ b/libs/sveltekit/src/components/360-DegreeImageViewer/360-DegreeImageViewer.stories.ts
@@ -1,5 +1,5 @@
 import DegreeImageViewer from './360-DegreeImageViewer.svelte';
-import type { Meta, Story } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta = {
   title: 'Components/Media/360-DegreeImageViewer',
@@ -7,7 +7,7 @@ const meta: Meta = {
   tags: ['autodocs'],
   argTypes: {
     imageUrls: {
-      control: { type: 'array' },
+      control: { type: 'object' },
     },
     isLoading: {
       control: { type: 'boolean' },
@@ -23,7 +23,7 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   Component: DegreeImageViewer,
   props: args,
 });

--- a/libs/sveltekit/src/components/360-DegreeImageViewer/360-DegreeImageViewer.svelte
+++ b/libs/sveltekit/src/components/360-DegreeImageViewer/360-DegreeImageViewer.svelte
@@ -7,7 +7,7 @@
   export let isZoomed: boolean = false;
 
   let currentIndex = 0;
-  let interval: NodeJS.Timer;
+  let interval: ReturnType<typeof setInterval>;
   let zoomLevel = 1;
 
   const startRotation = () => {
@@ -33,7 +33,7 @@
   });
 </script>
 
-<div class="viewer-container" aria-label="360 Degree Image Viewer" role="region" tabindex="0" on:click={toggleZoom} on:keydown={(e) => e.key === 'Enter' && toggleZoom()}>
+<div role="button" class="viewer-container" aria-label="360 Degree Image Viewer" tabindex="0" on:click={toggleZoom} on:keydown={(e) => e.key === 'Enter' && toggleZoom()}>
   {#if isLoading}
     <div class="loading" role="status" aria-live="polite">Loading...</div>
   {:else}


### PR DESCRIPTION
fix(360-DegreeImageViewer.stories.ts): Fix StoryFn import error.
Correctly import the StoryFn module from storybook/svelte.

fix(360-DegreeImageViewr.svelte): Fix type error and non-interactive elements errors.
- Set the interval's variable type to the correct return type which is setInterval
- Set the main div's role to button to resolve the non-interactive elements cannot be passed interactivity error.