### PR TITLE
AudioPlayerAdvanced - SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.stories.ts
+++ b/libs/sveltekit/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.stories.ts
@@ -1,5 +1,5 @@
 import AudioPlayerAdvanced from './AudioPlayerAdvanced.svelte';
-import type { Meta, Story } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta = {
   title: 'Components/Media/AudioPlayerAdvanced',
@@ -26,7 +26,7 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   Component: AudioPlayerAdvanced,
   props: args,
 });

--- a/libs/sveltekit/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.svelte
+++ b/libs/sveltekit/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.svelte
@@ -8,6 +8,7 @@
   export let playbackRate: number = 1;
 
   let audioElement: HTMLAudioElement;
+  let duration:number = 0;
 
   const togglePlay = () => {
     if (isPlaying) {
@@ -42,6 +43,9 @@
   onMount(() => {
     audioElement.volume = volume;
     audioElement.playbackRate = playbackRate;
+    audioElement.addEventListener('loadedmetadata', () => {
+      duration = audioElement.duration;
+    });
   });
 </script>
 
@@ -53,7 +57,7 @@
   <button on:click={toggleMute} on:keydown={(e) => e.key === 'Enter' && toggleMute()} aria-label={isMuted ? 'Unmute' : 'Mute'}>
     {#if isMuted}Unmute{:else}Mute{/if}
   </button>
-  <input type="range" min="0" max="{audioElement.duration}" step="0.1" on:input={handleSeek} aria-label="Seek Control" />
+  <input type="range" min="0" max="{duration}" step="0.1" on:input={handleSeek} aria-label="Seek Control" />
   <input type="range" min="0" max="1" step="0.01" value={volume} on:input={handleVolumeChange} aria-label="Volume Control" />
   <input type="range" min="0.5" max="2" step="0.1" value={playbackRate} on:input={handlePlaybackRateChange} aria-label="Speed Control" />
 </div>


### PR DESCRIPTION
fix(AudioPlayerAdvanced.stories.ts): Resolve StoryFn correct module import.

fix: resolve audio duration initialization issue in AudioPlayerAdvanced
- Add dedicated duration state variable to handle audio length
- Implement loadedmetadata event listener to properly initialize duration
- Move duration access from template to controlled state variable

This fixes the undefined duration error that occurred when trying to access
audioElement.duration before the audio metadata was fully loaded. The solution
ensures the seek control's max value is properly set only after the audio
file's metadata is available.

Technical changes:
- Added duration: number = 0 state variable
- Added loadedmetadata event listener in onMount
- Updated seek control input to use duration variable instead of direct property access