### PR TITLE
AudioWaveformDisplay- SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/AudioWaveformDisplay/AudioWaveformDisplay.stories.ts
+++ b/libs/sveltekit/src/components/AudioWaveformDisplay/AudioWaveformDisplay.stories.ts
@@ -1,5 +1,5 @@
 import AudioWaveformDisplay from './AudioWaveformDisplay.svelte';
-import type { Meta, Story } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta = {
   title: 'Components/Media/AudioWaveformDisplay',
@@ -26,7 +26,7 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   Component: AudioWaveformDisplay,
   props: args,
 });

--- a/libs/sveltekit/src/components/AudioWaveformDisplay/AudioWaveformDisplay.svelte
+++ b/libs/sveltekit/src/components/AudioWaveformDisplay/AudioWaveformDisplay.svelte
@@ -3,7 +3,7 @@
 
   export let src: string = '';
   export let isPlaying: boolean = false;
-  export let isLoading: boolean = false;
+  export const isLoading: boolean = false;
   export let currentTime: number = 0;
   export let duration: number = 0;
 


### PR DESCRIPTION
fix(AudioWaveformDisplay.stories.ts): Resolve StoryFn correct module import.

fix(AudioWaveformDisplay.svelte): Resolve unused variable error by exporting it as a constant as it is used externaly.