### PR TITLE
Captcha - SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/Captcha/Captcha.stories.ts
+++ b/libs/sveltekit/src/components/Captcha/Captcha.stories.ts
@@ -1,5 +1,5 @@
 import Captcha from './Captcha.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<Captcha> = {
   title: 'component/Forms/Captcha',
@@ -26,27 +26,27 @@ const meta: Meta<Captcha> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<Captcha> = (args) => ({
+  Component: Captcha,
+  props:args
+});
 
-export const Default: Story = {
-  args: {
-    question: 'What is 2 + 2?',
-    errorMessage: '',
-    solved: false,
-  }
+export const Default = Template.bind({});
+Default.args = {
+  question: 'What is 2 + 2 ?',
+  errorMessage: '',
+  solved:false,
 };
 
-export const Solved: Story = {
-  args: {
-    question: 'What is 2 + 2?',
-    solved: true,
-  }
+export const Solved = Template.bind({});
+Solved.args = {
+  question: 'What is 2 + 2 ?',
+  solved:true,
 };
 
-export const Error: Story = {
-  args: {
-    question: 'What is 2 + 2?',
-    errorMessage: 'Incorrect answer, please try again.',
-    solved: false,
-  }
+export const Error = Template.bind({});
+Error.args = {
+  question: 'What is 2 + 2 ?',
+  errorMessage: 'Incorrect answer, please try again',
+  solved:false,
 };


### PR DESCRIPTION
fix(Captcha.stories.ts): Resolve TypeScript error for Captcha.storiests args  props

- Updated the Captcha story file to correctly import the Captcha component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, the Captcha component can now be used in Storybook without type errors, and the props can be controlled as intended.