### PR TITLE
CardBasedList-SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/CardbasedList/CardbasedList.stories.ts
+++ b/libs/sveltekit/src/components/CardbasedList/CardbasedList.stories.ts
@@ -1,5 +1,5 @@
 import CardbasedList from './CardbasedList.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<CardbasedList> = {
   title: 'component/Lists/CardbasedList',
@@ -23,47 +23,46 @@ const meta: Meta<CardbasedList> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<CardbasedList> = (args) => ({
+  Component:CardbasedList,
+  props:args,
+});
 
-export const Default: Story = {
-  args: {
-    cards: [
-      { id: 1, title: 'Card 1', description: 'This is card 1 description' },
-      { id: 2, title: 'Card 2', description: 'This is card 2 description' },
-      { id: 3, title: 'Card 3', description: 'This is card 3 description' }
-    ]
-  }
+export const Default = Template.bind({});
+Default.args = {
+  cards: [
+    { id: 1, title: 'Card 1', description: 'This is card 1 description' },
+    { id: 2, title: 'Card 2', description: 'This is card 2 description' },
+    { id: 3, title: 'Card 3', description: 'This is card 3 description' }, 
+  ]
 };
 
-export const Hover: Story = {
-  args: {
-    cards: [
-      { id: 1, title: 'Card 1', description: 'This is card 1 description' },
-      { id: 2, title: 'Card 2', description: 'This is card 2 description' },
-      { id: 3, title: 'Card 3', description: 'This is card 3 description' }
-    ]
-  },
-  parameters: {
-    pseudo: { hover: true }
-  }
+export const Hover = Template.bind({});
+Hover.args = {
+  cards: [
+    { id: 1, title: 'Card 1', description: 'This is card 1 description' },
+    { id: 2, title: 'Card 2', description: 'This is card 2 description' },
+    { id: 3, title: 'Card 3', description: 'This is card 3 description' }, 
+  ]
+};
+Hover.parameters = {
+  pseudo: {hover:true},
 };
 
-export const Selected: Story = {
-  args: {
-    cards: [
-      { id: 1, title: 'Card 1', description: 'This is card 1 description', selected: true },
-      { id: 2, title: 'Card 2', description: 'This is card 2 description', selected: false },
-      { id: 3, title: 'Card 3', description: 'This is card 3 description', selected: true }
-    ]
-  }
+export const Selected = Template.bind({});
+Selected.args = {
+  cards: [
+    { id: 1, title: 'Card 1', description: 'This is card 1 description', selected:true, },
+    { id: 2, title: 'Card 2', description: 'This is card 2 description', selected:false,},
+    { id: 3, title: 'Card 3', description: 'This is card 3 description', selected:true, }, 
+  ]
 };
 
-export const Disabled: Story = {
-  args: {
-    cards: [
-      { id: 1, title: 'Card 1', description: 'This is card 1 description', disabled: true },
-      { id: 2, title: 'Card 2', description: 'This is card 2 description' },
-      { id: 3, title: 'Card 3', description: 'This is card 3 description', disabled: true }
-    ]
-  }
+export const Disabled = Template.bind({});
+Disabled.args = {
+  cards: [
+    { id: 1, title: 'Card 1', description: 'This is card 1 description', disabled:true, },
+    { id: 2, title: 'Card 2', description: 'This is card 2 description', disabled:false,},
+    { id: 3, title: 'Card 3', description: 'This is card 3 description', disabled:true, }, 
+  ]
 };

--- a/libs/sveltekit/src/components/CardbasedList/CardbasedList.svelte
+++ b/libs/sveltekit/src/components/CardbasedList/CardbasedList.svelte
@@ -14,6 +14,9 @@
       class="card {card.selected ? 'selected' : ''} {card.disabled ? 'disabled' : ''}" 
       on:click={() => selectCard(card)} 
       aria-disabled={card.disabled}
+      role ='button'
+      tabindex = "0"
+      on:keydown={(e)=> e.key === 'Enter' && selectCard(card)} 
     >
       <h2>{card.title}</h2>
       <p>{card.description}</p>


### PR DESCRIPTION
fix(CardbasedList.stories.ts): Resolve TypeScript error for CardbasedList.stories.ts args  props
- Updated the CardBasedList story file to correctly import the CardBasedList component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, the CardBasedList component can now be used in Storybook without type errors, and the props can be controlled as intended.

fix(CardbasedList.svelte): enhance accessibility of card elements
- Changed <div> to have role="button" and tabindex="0" for keyboard navigation.
- Added on:keydown event handler to allow selection via the Enter key.
- Ensured compliance with accessibility standards for interactive elements.