### PR TITLE
Carousel-SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/Carousel/Carousel.stories.ts
+++ b/libs/sveltekit/src/components/Carousel/Carousel.stories.ts
@@ -1,5 +1,5 @@
 import Carousel from './Carousel.svelte';
-import type { Meta, Story } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta = {
   title: 'Components/Media/Carousel',
@@ -7,7 +7,7 @@ const meta: Meta = {
   tags: ['autodocs'],
   argTypes: {
     images: {
-      control: { type: 'array' },
+      control: { type: 'object' },
     },
     autoPlay: {
       control: { type: 'boolean' },
@@ -20,7 +20,7 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn<Carousel> = (args) => ({
   Component: Carousel,
   props: args,
 });

--- a/libs/sveltekit/src/components/Carousel/Carousel.svelte
+++ b/libs/sveltekit/src/components/Carousel/Carousel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { writable } from 'svelte/store';
+  import { writable,get } from 'svelte/store';
 
   export let images: string[] = [];
   export let autoPlay: boolean = false;


### PR DESCRIPTION
fix(Carousel.stories.ts): Resolve incorrect import for the StoryFn module.
- Correctly Import the StoryFn from '@storybook/svelte'.

- Pass the correct control type for the images props which is object according to Storybook.

fix(Carousel.svelte): Resolve 'Cannot find name get' error in Carousel component
- Added the missing import for the `get` function from `svelte/store` in the Carousel.svelte file.
- This change ensures that the `get` function can be used to retrieve the current value of the `isHovered` writable store, preventing runtime errors during the autoplay functionality.
- The fix enhances the stability of the carousel component, particularly when the autoplay feature is enabled.