### PR TITLE
Checklist-SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/CheckList/CheckList.stories.ts
+++ b/libs/sveltekit/src/components/CheckList/CheckList.stories.ts
@@ -1,5 +1,5 @@
 import CheckList from './CheckList.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<CheckList> = {
   title: 'component/Lists/CheckList',
@@ -23,54 +23,52 @@ const meta: Meta<CheckList> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<CheckList>  = (args) => ({
+  Component: CheckList,
+  props: args,
+});
 
-export const Default: Story = {
-  args: {
-    items: [
-      { id: 1, label: 'Item 1' },
-      { id: 2, label: 'Item 2' },
-      { id: 3, label: 'Item 3' }
-    ]
-  }
+export const Default = Template.bind({});
+Default.args = {
+  items : [
+    { id: 1, label: 'Item 1' },
+    { id: 2, label: 'Item 2' },
+    { id: 3, label: 'Item 3' },
+  ],
 };
 
-export const Checked: Story = {
-  args: {
-    items: [
-      { id: 1, label: 'Item 1', checked: true },
-      { id: 2, label: 'Item 2' },
-      { id: 3, label: 'Item 3', checked: true }
-    ]
-  }
+export const Checked = Template.bind({});
+Checked.args = {
+  items : [
+    { id: 1, label: 'Item 1', checked:true, },
+    { id: 2, label: 'Item 2', checked:false, },
+    { id: 3, label: 'Item 3' , checked:true, },
+  ],
 };
 
-export const Unchecked: Story = {
-  args: {
-    items: [
-      { id: 1, label: 'Item 1', checked: false },
-      { id: 2, label: 'Item 2', checked: false },
-      { id: 3, label: 'Item 3', checked: false }
-    ]
-  }
+export const UnChecked = Template.bind({});
+UnChecked.args = {
+  items : [
+    { id: 1, label: 'Item 1', checked:false, },
+    { id: 2, label: 'Item 2', checked:false, },
+    { id: 3, label: 'Item 3' , checked:false, },
+  ],
 };
 
-export const PartiallyChecked: Story = {
-  args: {
-    items: [
-      { id: 1, label: 'Item 1', partiallyChecked: true },
-      { id: 2, label: 'Item 2' },
-      { id: 3, label: 'Item 3', partiallyChecked: true }
-    ]
-  }
+export const PartiallyChecked = Template.bind({});
+PartiallyChecked.args = {
+  items : [
+    { id: 1, label: 'Item 1', partiallyChecked:true, },
+    { id: 2, label: 'Item 2', partiallyChecked:false, },
+    { id: 3, label: 'Item 3' , partiallyChecked:true, },
+  ],
 };
 
-export const Disabled: Story = {
-  args: {
-    items: [
-      { id: 1, label: 'Item 1', disabled: true },
-      { id: 2, label: 'Item 2' },
-      { id: 3, label: 'Item 3', disabled: true }
-    ]
-  }
+export const Disabled = Template.bind({});
+Disabled.args = {
+  items : [
+    { id: 1, label: 'Item 1', disabled:true, },
+    { id: 2, label: 'Item 2', disabled:false, },
+    { id: 3, label: 'Item 3' , disabled:true, },
+  ],
 };

--- a/libs/sveltekit/src/components/CheckList/CheckList.svelte
+++ b/libs/sveltekit/src/components/CheckList/CheckList.svelte
@@ -24,8 +24,9 @@
         on:change={() => toggleCheck(item)} 
         disabled={item.disabled}
         aria-checked={item.partiallyChecked ? 'mixed' : item.checked}
+        id={`checkbox-${item.id}`}
       />
-      <label>{item.label}</label>
+      <label for={`checkbox-${item.id}`}>{item.label}</label>
     </li>
   {/each}
 </ul>


### PR DESCRIPTION
fix(CheckList.stories.ts): Resolve TypeScript error for CheckList.stories.ts args  props
- Updated the CheckList story file to correctly import the CheckList component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, the CheckList component can now be used in Storybook without type errors, and the props can be controlled as intended.

fix(CheckList.svelte): Fix accessibility issue by associating labels with checkboxes in CheckList component.