### PR TITLE
DatePicker-SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/DatePicker/DatePicker.stories.ts
+++ b/libs/sveltekit/src/components/DatePicker/DatePicker.stories.ts
@@ -1,5 +1,5 @@
 import DatePicker from './DatePicker.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<DatePicker> = {
   title: 'component/Forms/DatePicker',
@@ -27,26 +27,26 @@ const meta: Meta<DatePicker> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<DatePicker> = (args) => ({
+  Component: DatePicker,
+  props:args,
+});
 
-export const SingleDate: Story = {
-  args: {
-    date: '',
-    mode: 'single',
-  }
+export const SingleDate = Template.bind({});
+SingleDate.args = {
+  date:'',
+  mode:'single',
 };
 
-export const DateRange: Story = {
-  args: {
-    startDate: '',
-    endDate: '',
-    mode: 'range',
-  }
+export const DateRange = Template.bind({});
+DateRange.args = {
+  startDate:'',
+  endDate:'',
+  mode:'range',
 };
 
-export const TimePicker: Story = {
-  args: {
-    time: '',
-    mode: 'time',
-  }
+export const TimePicker = Template.bind({});
+TimePicker.args = {
+  time:'',
+  mode:'time',
 };


### PR DESCRIPTION
fix(DatePicker.stories.ts): Resolve TypeScript error for DatePicker.stories.ts args  props

- Updated the DatePicker story file to correctly import the DatePicker component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, DatePicker component can now be used in Storybook without type errors, and the props can be controlled as intended.