### PR TITLE
GroupedList-SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/GroupedList/GroupedList.stories.ts
+++ b/libs/sveltekit/src/components/GroupedList/GroupedList.stories.ts
@@ -1,5 +1,6 @@
 import GroupedList from './GroupedList.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
+import {userEvent, within} from '@storybook/test';
 
 const meta: Meta<GroupedList> = {
   title: 'component/Lists/GroupedList',
@@ -23,59 +24,57 @@ const meta: Meta<GroupedList> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<GroupedList> = (args) => ({
+  Component: GroupedList,
+  props:args,
+});
 
-export const Default: Story = {
-  args: {
-    groups: [
-      { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
-      { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false }
-    ]
-  }
+export const Default = Template.bind({});
+Default.args = {
+  groups: [
+    { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
+    { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false },
+  ]
 };
 
-export const GroupExpanded: Story = {
-  args: {
-    groups: [
-      { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
-      { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false }
-    ]
-  }
+export const GroupExpanded = Template.bind({});
+GroupExpanded.args = {
+  groups: [
+    { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
+    { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false },
+  ]
 };
 
-export const GroupCollapsed: Story = {
-  args: {
-    groups: [
-      { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: false },
-      { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false }
-    ]
-  }
+export const GroupCollapsed = Template.bind({});
+GroupCollapsed.args = {
+  groups: [
+    { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: false },
+    { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false },
+  ]
 };
 
-export const ItemHover: Story = {
-  args: {
-    groups: [
-      { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
-      { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false }
-    ]
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const listItem = canvas.getByText('Banana');
-    await userEvent.hover(listItem);
-  }
+export const ItemHover = Template.bind({});
+ItemHover.args = {
+  groups: [
+    { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
+    { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false },
+  ]
+};
+ItemHover.play = async({canvasElement}) => {
+  const canvas = within(canvasElement);
+  const listItem = canvas.getByText('Banana');
+  await userEvent.hover(listItem);
 };
 
-export const ItemSelected: Story = {
-  args: {
-    groups: [
-      { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
-      { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false }
-    ]
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const listItem = canvas.getByText('Banana');
-    await userEvent.click(listItem);
-  }
+export const ItemSelected = Template.bind({});
+ItemSelected.args = {
+  groups: [
+    { title: 'Fruits', items: ['Apple', 'Banana', 'Cherry'], expanded: true },
+    { title: 'Vegetables', items: ['Carrot', 'Lettuce', 'Peas'], expanded: false },
+  ]
+};
+ItemSelected.play = async({canvasElement}) => {
+  const canvas = within(canvasElement);
+  const listItem = canvas.getByText('Banana');
+  await userEvent.click(listItem);
 };

--- a/libs/sveltekit/src/components/GroupedList/GroupedList.svelte
+++ b/libs/sveltekit/src/components/GroupedList/GroupedList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { writable } from 'svelte/store';
 
-  export interface Group {
+  interface Group {
     title: string;
     items: string[];
     expanded?: boolean;
@@ -31,7 +31,10 @@
             <li 
               class:selected={selectedItem === item} 
               on:click={() => selectItem(item)} 
-              on:mouseover={() => selectItem(item)}>
+              on:keydown={(e)=>{if(e.key === 'Enter' || e.key === ' '){selectItem(item)}}}
+              on:mouseover={() => selectItem(item)}
+              on:focus= {()=> selectItem(item)}
+              role='menuitem'>
               {item}
             </li>
           {/each}


### PR DESCRIPTION
fix(GroupedList.stories.ts): Resolve TypeScript error for GroupedList.stories.ts args props
- Updated the GroupedList story file to correctly import the GroupedList component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, GroupedList component can now be used in Storybook without type errors, and the props can be controlled as intended.

fix(GroupedList.svelte): Add keyboard event handler to selected-item for accessibility.
- Added on:keydown event to the selected li to handle keyboard interactions (Enter and Space keys).
- Follow up with a on:focus event to the selected li to handle focus interactions.