### PR TITLE
ImageSlider-SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/ImageSlider/ImageSlider.stories.ts
+++ b/libs/sveltekit/src/components/ImageSlider/ImageSlider.stories.ts
@@ -1,5 +1,5 @@
 import ImageSlider from './ImageSlider.svelte';
-import type { Meta, Story } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta = {
   title: 'Components/Media/ImageSlider',
@@ -7,7 +7,7 @@ const meta: Meta = {
   tags: ['autodocs'],
   argTypes: {
     images: {
-      control: { type: 'array' },
+      control: { type: 'object' },
     },
     activeIndex: {
       control: { type: 'number' },
@@ -17,7 +17,7 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn = (args) => ({
   Component: ImageSlider,
   props: args,
 });

--- a/libs/sveltekit/src/components/ImageSlider/ImageSlider.svelte
+++ b/libs/sveltekit/src/components/ImageSlider/ImageSlider.svelte
@@ -19,7 +19,7 @@
   };
 </script>
 
-<div class="image-slider" role="region" aria-label="Image Slider" tabindex="0" on:keydown={handleKeydown}>
+<div class="image-slider" role="menu" aria-label="Image Slider" tabindex="0" on:keydown={handleKeydown}>
   {#if images.length > 0}
     <img src={images[activeIndex]} alt={`Image ${activeIndex + 1}`} class="slider-image" />
     <div class="controls">


### PR DESCRIPTION
fix(ImageSlider.stories.ts): Fix incorrect import module for the StoryFn module.

fix(ImageSlider.svelte): Change the image-slider role to menu to accommodate events.