### PR TITLE
LoadingBarsWithSteps-SvelteKit

### DIFF
--- a/libs/sveltekit/src/components/LoadingBarsWithSteps/LoadingBarsWithSteps.stories.ts
+++ b/libs/sveltekit/src/components/LoadingBarsWithSteps/LoadingBarsWithSteps.stories.ts
@@ -1,5 +1,5 @@
 import LoadingBarsWithSteps from './LoadingBarsWithSteps.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<LoadingBarsWithSteps> = {
   title: 'component/Indicators/LoadingBarsWithSteps',
@@ -23,44 +23,43 @@ const meta: Meta<LoadingBarsWithSteps> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<LoadingBarsWithSteps> = (args) => ({
+  Component:LoadingBarsWithSteps,
+  props:args,
+});
 
-export const Default: Story = {
-  args: {
-    steps: [
-      { label: 'Step 1', status: 'active' },
-      { label: 'Step 2', status: 'inactive' },
-      { label: 'Step 3', status: 'inactive' },
-    ],
-  }
+export const Default = Template.bind({});
+Default.args = {
+  steps: [
+    { label: 'Step 1', status: 'active' },
+    { label: 'Step 2', status: 'inactive' },
+    { label: 'Step 3', status: 'inactive' },
+  ],
 };
 
-export const StepActive: Story = {
-  args: {
-    steps: [
-      { label: 'Step 1', status: 'completed' },
-      { label: 'Step 2', status: 'active' },
-      { label: 'Step 3', status: 'inactive' },
-    ],
-  }
+export const StepActive = Template.bind({});
+StepActive.args = {
+  steps: [
+    { label: 'Step 1', status: 'completed' },
+    { label: 'Step 2', status: 'active' },
+    { label: 'Step 3', status: 'inactive' },
+  ],
 };
 
-export const StepCompleted: Story = {
-  args: {
-    steps: [
-      { label: 'Step 1', status: 'completed' },
-      { label: 'Step 2', status: 'completed' },
-      { label: 'Step 3', status: 'active' },
-    ],
-  }
+export const StepCompleted = Template.bind({});
+StepCompleted.args = {
+  steps: [
+    { label: 'Step 1', status: 'completed' },
+    { label: 'Step 2', status: 'completed' },
+    { label: 'Step 3', status: 'active' },
+  ],
 };
 
-export const StepInactive: Story = {
-  args: {
-    steps: [
-      { label: 'Step 1', status: 'completed' },
-      { label: 'Step 2', status: 'completed' },
-      { label: 'Step 3', status: 'inactive' },
-    ],
-  }
+export const StepInActive = Template.bind({});
+StepInActive.args = {
+  steps: [
+    { label: 'Step 1', status: 'completed' },
+    { label: 'Step 2', status: 'completed' },
+    { label: 'Step 3', status: 'inactive' },
+  ],
 };

--- a/libs/sveltekit/src/components/LoadingBarsWithSteps/LoadingBarsWithSteps.svelte
+++ b/libs/sveltekit/src/components/LoadingBarsWithSteps/LoadingBarsWithSteps.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export type Step = {
+  type Step = {
     label: string;
     status: 'active' | 'completed' | 'inactive';
   };


### PR DESCRIPTION
fix(LoadingBarsWithSteps.svelte): Remove the export keyword from the type declaration Step as it was accessed internally by steps variable.

fix(LoadingBarsWithSteps.stories.ts): Resolve TypeScript error for LoadingBarsWithSteps.stories.ts args props
- Updated the LoadingBarsWIthSteps story file to correctly import the LoadingBarsWithSteps component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, LoadingBarsWithSteps component can now be used in Storybook without type errors, and the props can be controlled as intended.