### PR TITLE
NumberedList-Svelte

### DIFF
--- a/libs/sveltekit/src/components/NumberedList/NumberedList.stories.ts
+++ b/libs/sveltekit/src/components/NumberedList/NumberedList.stories.ts
@@ -1,5 +1,5 @@
 import NumberedList from './NumberedList.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<NumberedList> = {
   title: 'component/Lists/NumberedList',
@@ -24,48 +24,47 @@ const meta: Meta<NumberedList> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<NumberedList> = (args) => ({
+  Component:NumberedList,
+  props:args,
+});
 
-export const Default: Story = {
-  args: {
-    items: [
-      { id: '1', label: 'Item 1', selected: false },
-      { id: '2', label: 'Item 2', selected: false },
-      { id: '3', label: 'Item 3', selected: false }
-    ],
-    disabled: false
-  }
+export const Default = Template.bind({});
+Default.args = {
+  items: [
+    { id: '1', label: 'Item 1', selected: false },
+    { id: '2', label: 'Item 2', selected: false },
+    { id: '3', label: 'Item 3', selected: false }
+  ],
+  disabled:false,
 };
 
-export const Selected: Story = {
-  args: {
-    items: [
-      { id: '1', label: 'Item 1', selected: true },
-      { id: '2', label: 'Item 2', selected: false },
-      { id: '3', label: 'Item 3', selected: false }
-    ],
-    disabled: false
-  }
+export const Selected = Template.bind({});
+Selected.args = {
+  items: [
+    { id: '1', label: 'Item 1', selected: true },
+    { id: '2', label: 'Item 2', selected: false },
+    { id: '3', label: 'Item 3', selected: false }
+  ],
+  disabled:false,
 };
 
-export const Hover: Story = {
-  args: {
-    items: [
-      { id: '1', label: 'Item 1', selected: false },
-      { id: '2', label: 'Item 2', selected: false },
-      { id: '3', label: 'Item 3', selected: false }
-    ],
-    disabled: false
-  }
+export const Hover = Template.bind({});
+Hover.args = {
+  items: [
+    { id: '1', label: 'Item 1', selected: false },
+    { id: '2', label: 'Item 2', selected: false },
+    { id: '3', label: 'Item 3', selected: false }
+  ],
+  disabled:false,
 };
 
-export const Disabled: Story = {
-  args: {
-    items: [
-      { id: '1', label: 'Item 1', selected: false },
-      { id: '2', label: 'Item 2', selected: false },
-      { id: '3', label: 'Item 3', selected: false }
-    ],
-    disabled: true
-  }
+export const Disabled = Template.bind({});
+Disabled.args = {
+  items: [
+    { id: '1', label: 'Item 1', selected: false },
+    { id: '2', label: 'Item 2', selected: false },
+    { id: '3', label: 'Item 3', selected: false }
+  ],
+  disabled:true,
 };

--- a/libs/sveltekit/src/components/NumberedList/NumberedList.svelte
+++ b/libs/sveltekit/src/components/NumberedList/NumberedList.svelte
@@ -19,6 +19,8 @@
       aria-selected={selected}
       aria-disabled={disabled}
       tabindex={disabled ? -1 : 0}
+      on:keydown={(e)=>{if(e.key === 'Enter' || e.key === ' '){handleSelect(id)}}}
+      role="tab"
     >
       {label}
     </li>


### PR DESCRIPTION
fix(NumberedList.stories.ts): Resolve TypeScript error for NumberedList.stories.ts args props
- Updated the NumberedList story file to correctly import the NumberedList component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, NumberedList component can now be used in Storybook without type errors, and the props can be controlled as intended.

fix(NumberedList.svelte): Resolve accessibility errors by giving the `list-item` div a role of tab.
- Give the `list-item` div a role of tab and also a key down event to resolve accessibility issues.