### PR TITLE
PinnedList - Svelte

### DIFF
--- a/libs/sveltekit/src/components/PinnedList/PinnedList.stories.ts
+++ b/libs/sveltekit/src/components/PinnedList/PinnedList.stories.ts
@@ -1,5 +1,5 @@
 import PinnedList from './PinnedList.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta<PinnedList> = {
   title: 'component/Lists/PinnedList',
@@ -24,59 +24,58 @@ const meta: Meta<PinnedList> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<PinnedList> = (args) => ({
+  Component: PinnedList,
+  props: args,
+}); 
 
-export const Default: Story = {
-  args: {
-    items: [
-      { id: 1, text: 'Item 1', pinned: false },
-      { id: 2, text: 'Item 2', pinned: false },
-      { id: 3, text: 'Item 3', pinned: false }
-    ],
-    selectedItem: null
-  }
+export const Default = Template.bind({});
+Default.args = {
+  items: [
+    { id: 1, text: 'Item 1', pinned: false },
+    { id: 2, text: 'Item 2', pinned: false },
+    { id: 3, text: 'Item 3', pinned: false }
+  ],
+  selectedItem: null
 };
 
-export const Pinned: Story = {
-  args: {
-    items: [
-      { id: 1, text: 'Item 1', pinned: true },
-      { id: 2, text: 'Item 2', pinned: false },
-      { id: 3, text: 'Item 3', pinned: false }
-    ],
-    selectedItem: null
-  }
+export const Pinned = Template.bind({});
+Pinned.args = {
+  items: [
+    { id: 1, text: 'Item 1', pinned: true },
+    { id: 2, text: 'Item 2', pinned: false },
+    { id: 3, text: 'Item 3', pinned: false }
+  ],
+  selectedItem: null
 };
 
-export const Unpinned: Story = {
-  args: {
-    items: [
-      { id: 1, text: 'Item 1', pinned: false },
-      { id: 2, text: 'Item 2', pinned: false },
-      { id: 3, text: 'Item 3', pinned: false }
-    ],
-    selectedItem: null
-  }
+export const Unpinned = Template.bind({});
+Unpinned.args = {
+  items: [
+    { id: 1, text: 'Item 1', pinned: false },
+    { id: 2, text: 'Item 2', pinned: false },
+    { id: 3, text: 'Item 3', pinned: false }
+  ],
+  selectedItem: null
 };
 
-export const Hover: Story = {
-  args: {
-    items: [
-      { id: 1, text: 'Item 1', pinned: false },
-      { id: 2, text: 'Item 2', pinned: false },
-      { id: 3, text: 'Item 3', pinned: false }
-    ],
-    selectedItem: null
-  }
+
+export const Hover = Template.bind({});
+Hover.args = {
+  items: [
+    { id: 1, text: 'Item 1', pinned: false },
+    { id: 2, text: 'Item 2', pinned: false },
+    { id: 3, text: 'Item 3', pinned: false }
+  ],
+  selectedItem: null
 };
 
-export const Selected: Story = {
-  args: {
-    items: [
-      { id: 1, text: 'Item 1', pinned: false },
-      { id: 2, text: 'Item 2', pinned: false },
-      { id: 3, text: 'Item 3', pinned: false }
-    ],
-    selectedItem: 2
-  }
+export const selectedItem = Template.bind({});
+selectedItem.args = {
+  items: [
+    { id: 1, text: 'Item 1', pinned: false },
+    { id: 2, text: 'Item 2', pinned: false },
+    { id: 3, text: 'Item 3', pinned: false }
+  ],
+  selectedItem: 2,
 };

--- a/libs/sveltekit/src/components/PinnedList/PinnedList.svelte
+++ b/libs/sveltekit/src/components/PinnedList/PinnedList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export type ListItem = {
+  type ListItem = {
     id: number;
     text: string;
     pinned: boolean;
@@ -22,7 +22,10 @@
     <li
       class="list-item {item.pinned ? 'pinned' : ''} {selectedItem === item.id ? 'selected' : ''}"
       on:click={() => selectItem(item.id)}
+      on:keydown={(e)=>{if(e.key === 'Enter' || e.key === ' '){selectItem(item.id)}}}
       aria-selected={selectedItem === item.id}
+      tabindex ="0"
+      role="tab"
     >
       <span class="item-text">{item.text}</span>
       <button


### PR DESCRIPTION
fix(PinnedList.stories.ts): Resolve TypeScript error for PinnedList.stories.ts args props
- Updated the PinnedList story file to correctly import the PinnedList component and define the `argTypes` for the props, allowing Storybook to properly handle the component's properties.
- This change addresses the TypeScript error: "Object literal may only specify known properties, and 'isOpen' does not exist in type 'Partial<ComponentAnnotations<...>>'" by ensuring that the props are correctly defined and typed in both the component and the story file.

With these updates, PinnedList component can now be used in Storybook without type errors, and the props can be controlled as intended.

fix(PinnedList.svelte): Resolve accessibility errors by giving the list-item li a role of tab.
- Give the list-item div a role of tab and also a key down event to resolve accessibility issues.

- Add keydown event to make the `list-item` accessible.