### PR TITLE
VirtualizedList - Sveltekit

### DIFF
--- a/libs/sveltekit/src/components/VirtualizedList/VirtualizedList.stories.ts
+++ b/libs/sveltekit/src/components/VirtualizedList/VirtualizedList.stories.ts
@@ -1,5 +1,5 @@
 import VirtualizedList from './VirtualizedList.svelte';
-import type { Meta, Story } from '@storybook/svelte';
+import type { Meta, StoryFn } from '@storybook/svelte';
 
 const meta: Meta = {
   title: 'Components/Lists/VirtualizedList',
@@ -7,7 +7,7 @@ const meta: Meta = {
   tags: ['autodocs'],
   argTypes: {
     items: {
-      control: { type: 'array' },
+      control: { type: 'object' },
     },
     isLoading: {
       control: { type: 'boolean' },
@@ -21,7 +21,7 @@ const meta: Meta = {
 
 export default meta;
 
-const Template: Story = (args) => ({
+const Template: StoryFn<VirtualizedList> = (args) => ({
   Component: VirtualizedList,
   props: args,
 });


### PR DESCRIPTION
Refactor VirtualizedList story: Change control type from `array` to `object` and update Story type to StoryFn

- Update the story import to StoryFn.