### PR TITLE
VisualCueForAccesisibiltyFocusIndicator - Sveltekit

### DIFF
--- a/libs/sveltekit/src/components/VisualCueForAccessibilityFocusIndicator/VisualCueForAccessibilityFocusIndicator.stories.ts
+++ b/libs/sveltekit/src/components/VisualCueForAccessibilityFocusIndicator/VisualCueForAccessibilityFocusIndicator.stories.ts
@@ -1,5 +1,5 @@
 import VisualCueForAccessibilityFocusIndicator from './VisualCueForAccessibilityFocusIndicator.svelte';
-import type { Meta, StoryObj } from '@storybook/svelte';
+import type { Meta, StoryFn, StoryObj } from '@storybook/svelte';
 
 const meta: Meta<VisualCueForAccessibilityFocusIndicator> = {
   title: 'component/Indicators/VisualCueForAccessibilityFocusIndicator',
@@ -23,22 +23,43 @@ const meta: Meta<VisualCueForAccessibilityFocusIndicator> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+const Template:StoryFn<VisualCueForAccessibilityFocusIndicator> = (args) => ({
+  Component: VisualCueForAccessibilityFocusIndicator,
+  props:args,
+});
 
-export const Default: Story = {
-  args: {
-    isFocused: false
-  }
-};
 
-export const Focused: Story = {
-  args: {
-    isFocused: true
-  }
-};
+export const Default = Template.bind({});
+Default.args = {
+  isFocused: false
+}
 
-export const Unfocused: Story = {
-  args: {
-    isFocused: false
-  }
-};
+export const Focused = Template.bind({});
+Focused.args = {
+  isFocused: true
+}
+
+export const Unfocused = Template.bind({});
+Unfocused.args = {
+  isFocused: false
+}
+
+// type Story = StoryObj<typeof meta>;
+
+// export const Default: Story = {
+//   args: {
+ //     isFocused: false
+//   }
+// };
+
+// export const Focused: Story = {
+//   args: {
+//     isFocused: true
+//   }
+// };
+
+// export const Unfocused: Story = {
+//   args: {
+//     isFocused: false
+//   }
+// };

--- a/libs/sveltekit/src/components/VisualCueForAccessibilityFocusIndicator/VisualCueForAccessibilityFocusIndicator.svelte
+++ b/libs/sveltekit/src/components/VisualCueForAccessibilityFocusIndicator/VisualCueForAccessibilityFocusIndicator.svelte
@@ -2,7 +2,7 @@
   export let isFocused: boolean = false;
 </script>
 
-<div class="focus-indicator" tabindex="0" class:is-focused={isFocused} aria-label="Focus indicator">
+<div class="focus-indicator" class:is-focused={isFocused} aria-label="Focus indicator">
   <p>Focus Indicator</p>
 </div>
 


### PR DESCRIPTION
Refactor Storybook stories for VisualCueForAccessibilityFocusIndicator component
- Updated import statements to include StoryFn type.

- Replaced the previous StoryObj definitions with a Template function for better reusability.

- Defined stories for Default, Focused, and Unfocused states using the new Template approach.

This change enhances the structure and maintainability of the Storybook stories.

Fix focus indicator class binding in VisualCueForAccessibilityFocusIndicator component
- Removed redundant tabindex attribute from the focus indicator div.

This change improves the accessibility and functionality of the focus indicator.