### PR TITLE
ActivityIndicators/ React

### DIFF
--- a/libs/react/src/components/Accordion/Accordion.stories.tsx
+++ b/libs/react/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import Accordion from './Accordion';
+import { Meta, StoryFn } from '@storybook/react';
+import Accordion, { AccordionProps } from './Accordion';
 
 export default {
   title: 'component/Lists/Accordion',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AccordionProps> = (args) => <Accordion {...args} />;
+const Template: StoryFn<AccordionProps> = (args) => <Accordion {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/Accordion/Accordion.tsx
+++ b/libs/react/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-interface AccordionProps {
+export interface AccordionProps {
   title: string;
   content: string;
   isOpen?: boolean;

--- a/libs/react/src/components/ActionSheet/ActionSheet.stories.tsx
+++ b/libs/react/src/components/ActionSheet/ActionSheet.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import ActionSheet, { ActionSheetProps } from './ActionSheet';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<ActionSheetProps> = (args) => <ActionSheet {...args} />;
+const Template: StoryFn<ActionSheetProps> = (args) => <ActionSheet {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/ActionSheet/ActionSheet.tsx
+++ b/libs/react/src/components/ActionSheet/ActionSheet.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-interface ActionSheetProps {
+export interface ActionSheetProps {
   isOpen: boolean;
   onClose: () => void;
   actions: { label: string; onClick: () => void }[];

--- a/libs/react/src/components/ActionableList/ActionableList.stories.tsx
+++ b/libs/react/src/components/ActionableList/ActionableList.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import ActionableList from './ActionableList';
+import { Meta, StoryFn } from '@storybook/react';
+import ActionableList,{ActionableListProps} from './ActionableList';
 
 export default {
   title: 'component/Lists/ActionableList',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<ActionableListProps> = (args) => <ActionableList {...args} />;
+const Template: StoryFn<ActionableListProps> = (args) => <ActionableList {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/ActionableList/ActionableList.tsx
+++ b/libs/react/src/components/ActionableList/ActionableList.tsx
@@ -7,7 +7,7 @@ interface ActionableListItem {
   disabled?: boolean;
 }
 
-interface ActionableListProps {
+export interface ActionableListProps {
   items: ActionableListItem[];
   onAction: (id: number) => void;
   isLoading?: boolean;

--- a/libs/react/src/components/ActivityIndicators/ActivityIndicators.stories.tsx
+++ b/libs/react/src/components/ActivityIndicators/ActivityIndicators.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import ActivityIndicators from './ActivityIndicators';
+import { Meta, StoryFn } from '@storybook/react';
+import ActivityIndicators, { ActivityIndicatorsProps } from './ActivityIndicators';
 
 export default {
   title: 'component/Indicators/ActivityIndicators',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => <ActivityIndicators {...args} />;
+const Template: StoryFn<ActivityIndicatorsProps> = (args) => <ActivityIndicators{...args} />;
 
 export const Loading = Template.bind({});
 Loading.args = {

--- a/libs/react/src/components/ActivityIndicators/ActivityIndicators.tsx
+++ b/libs/react/src/components/ActivityIndicators/ActivityIndicators.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface ActivityIndicatorsProps {
+export interface ActivityIndicatorsProps {
   state: 'loading' | 'success' | 'error';
 }
 


### PR DESCRIPTION
### Fixes:

- Changed the story template type from Story to StoryFn for improved compatibility with TypeScript.
- Imported ActivityIndicatorsProps to enhance type safety in the story definition.
- Changed the ActivityIndicatorsProps interface from private to exported to allow usage in other components and stories.
- This change enhances type safety and maintainability across the React components.