### PR TITLE
Banner / React

### DIFF
--- a/libs/react/src/components/Accordion/Accordion.stories.tsx
+++ b/libs/react/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import Accordion from './Accordion';
+import { Meta, StoryFn } from '@storybook/react';
+import Accordion, { AccordionProps } from './Accordion';
 
 export default {
   title: 'component/Lists/Accordion',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AccordionProps> = (args) => <Accordion {...args} />;
+const Template: StoryFn<AccordionProps> = (args) => <Accordion {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/Accordion/Accordion.tsx
+++ b/libs/react/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-interface AccordionProps {
+export interface AccordionProps {
   title: string;
   content: string;
   isOpen?: boolean;

--- a/libs/react/src/components/ActionSheet/ActionSheet.stories.tsx
+++ b/libs/react/src/components/ActionSheet/ActionSheet.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import ActionSheet, { ActionSheetProps } from './ActionSheet';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<ActionSheetProps> = (args) => <ActionSheet {...args} />;
+const Template: StoryFn<ActionSheetProps> = (args) => <ActionSheet {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/ActionSheet/ActionSheet.tsx
+++ b/libs/react/src/components/ActionSheet/ActionSheet.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-interface ActionSheetProps {
+export interface ActionSheetProps {
   isOpen: boolean;
   onClose: () => void;
   actions: { label: string; onClick: () => void }[];

--- a/libs/react/src/components/ActionableList/ActionableList.stories.tsx
+++ b/libs/react/src/components/ActionableList/ActionableList.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import ActionableList from './ActionableList';
+import { Meta, StoryFn } from '@storybook/react';
+import ActionableList,{ActionableListProps} from './ActionableList';
 
 export default {
   title: 'component/Lists/ActionableList',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<ActionableListProps> = (args) => <ActionableList {...args} />;
+const Template: StoryFn<ActionableListProps> = (args) => <ActionableList {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/ActionableList/ActionableList.tsx
+++ b/libs/react/src/components/ActionableList/ActionableList.tsx
@@ -7,7 +7,7 @@ interface ActionableListItem {
   disabled?: boolean;
 }
 
-interface ActionableListProps {
+export interface ActionableListProps {
   items: ActionableListItem[];
   onAction: (id: number) => void;
   isLoading?: boolean;

--- a/libs/react/src/components/ActivityIndicators/ActivityIndicators.stories.tsx
+++ b/libs/react/src/components/ActivityIndicators/ActivityIndicators.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import ActivityIndicators from './ActivityIndicators';
+import { Meta, StoryFn } from '@storybook/react';
+import ActivityIndicators, { ActivityIndicatorsProps } from './ActivityIndicators';
 
 export default {
   title: 'component/Indicators/ActivityIndicators',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => <ActivityIndicators {...args} />;
+const Template: StoryFn<ActivityIndicatorsProps> = (args) => <ActivityIndicators{...args} />;
 
 export const Loading = Template.bind({});
 Loading.args = {

--- a/libs/react/src/components/ActivityIndicators/ActivityIndicators.tsx
+++ b/libs/react/src/components/ActivityIndicators/ActivityIndicators.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface ActivityIndicatorsProps {
+export interface ActivityIndicatorsProps {
   state: 'loading' | 'success' | 'error';
 }
 

--- a/libs/react/src/components/AddMemberButton/AddMemberButton.stories.tsx
+++ b/libs/react/src/components/AddMemberButton/AddMemberButton.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import AddMemberButton, { AddMemberButtonProps } from './AddMemberButton';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AddMemberButtonProps> = (args) => <AddMemberButton {...args} />;
+const Template: StoryFn<AddMemberButtonProps> = (args) => <AddMemberButton {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/AddMemberButton/AddMemberButton.tsx
+++ b/libs/react/src/components/AddMemberButton/AddMemberButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AddMemberButtonProps {
+export interface AddMemberButtonProps {
   isEnabled: boolean;
   onClick: () => void;
 }

--- a/libs/react/src/components/AdminViewScheduler/AdminViewScheduler.stories.tsx
+++ b/libs/react/src/components/AdminViewScheduler/AdminViewScheduler.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import AdminViewScheduler, { AdminViewSchedulerProps } from './AdminViewScheduler';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AdminViewSchedulerProps> = (args) => <AdminViewScheduler {...args} />;
+const Template: StoryFn<AdminViewSchedulerProps> = (args) => <AdminViewScheduler {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
@@ -34,13 +34,13 @@ Default.args = {
 
 export const EventAdded = Template.bind({});
 EventAdded.args = {
-  initialEvents: [...Default.args.initialEvents],
+  initialEvents: [...(Default.args?.initialEvents || [])],
 };
 
 export const EventEdited = Template.bind({});
 EventEdited.args = {
   initialEvents: [
-    ...Default.args.initialEvents.map(event => 
+    ...(Default.args?.initialEvents || []).map(event => 
       event.id === '1' ? { ...event, title: 'Updated Team Meeting' } : event
     ),
   ],
@@ -48,5 +48,5 @@ EventEdited.args = {
 
 export const EventDeleted = Template.bind({});
 EventDeleted.args = {
-  initialEvents: Default.args.initialEvents.filter(event => event.id !== '1'),
+  initialEvents: (Default.args?.initialEvents || []).filter(event => event.id !== '1'),
 };

--- a/libs/react/src/components/AdminViewScheduler/AdminViewScheduler.tsx
+++ b/libs/react/src/components/AdminViewScheduler/AdminViewScheduler.tsx
@@ -10,7 +10,7 @@ interface Event {
   description: string;
 }
 
-interface AdminViewSchedulerProps {
+export interface AdminViewSchedulerProps {
   initialEvents: Event[];
 }
 

--- a/libs/react/src/components/AreaChart/AreaChart.stories.tsx
+++ b/libs/react/src/components/AreaChart/AreaChart.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import AreaChart, { AreaChartProps } from './AreaChart';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AreaChartProps> = (args) => <AreaChart {...args} />;
+const Template: StoryFn<AreaChartProps> = (args) => <AreaChart {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/AreaChart/AreaChart.tsx
+++ b/libs/react/src/components/AreaChart/AreaChart.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AreaChartProps {
+export interface AreaChartProps {
   state: 'loading' | 'rendered' | 'empty' | 'stacked' | 'hovered' | 'clicked' | 'tooltipVisible';
   data: Array<{ x: number; y: number; category?: string }>;
 }
@@ -14,11 +14,11 @@ const AreaChart: React.FC<AreaChartProps> = ({ state, data }) => {
     >
       {state === 'loading' && <div className="chart-loading">Loading...</div>}
       {state === 'empty' && <div className="chart-empty">No Data</div>}
-      {state === 'rendered' && /* Render the area chart using data */}
-      {state === 'stacked' && /* Render stacked area chart */}
-      {state === 'hovered' && /* Render area chart with hover effect */}
-      {state === 'clicked' && /* Render area chart with click effect */}
-      {state === 'tooltipVisible' && /* Render area chart with tooltip */}
+      {/* {state === 'rendered' &&  Render the area chart using data }
+      {state === 'stacked' && Render stacked area chart }
+      {state === 'hovered' && Render area chart with hover effect }
+      {state === 'clicked' && Render area chart with click effect }
+      {state === 'tooltipVisible' && Render area chart with tooltip } */}
     </div>
   );
 };

--- a/libs/react/src/components/AttachmentIcon/AttachmentIcon.stories.tsx
+++ b/libs/react/src/components/AttachmentIcon/AttachmentIcon.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import AttachmentIcon, { AttachmentIconProps } from './AttachmentIcon';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AttachmentIconProps> = (args) => <AttachmentIcon {...args} />;
+const Template: StoryFn<AttachmentIconProps> = (args) => <AttachmentIcon {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {};

--- a/libs/react/src/components/AttachmentIcon/AttachmentIcon.tsx
+++ b/libs/react/src/components/AttachmentIcon/AttachmentIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AttachmentIconProps {
+export interface AttachmentIconProps {
   disabled?: boolean;
   onClick?: () => void;
 }

--- a/libs/react/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/libs/react/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import AudioPlayer, { AudioPlayerProps } from './AudioPlayer';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AudioPlayerProps> = (args) => <AudioPlayer {...args} />;
+const Template: StoryFn<AudioPlayerProps> = (args) => <AudioPlayer {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/libs/react/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 
-interface AudioPlayerProps {
+export interface AudioPlayerProps {
   src: string;
 }
 

--- a/libs/react/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.stories.tsx
+++ b/libs/react/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import AudioPlayerAdvanced, { AudioPlayerAdvancedProps } from './AudioPlayerAdvanced';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AudioPlayerAdvancedProps> = (args) => <AudioPlayerAdvanced {...args} />;
+const Template: StoryFn<AudioPlayerAdvancedProps> = (args) => <AudioPlayerAdvanced {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.tsx
+++ b/libs/react/src/components/AudioPlayerAdvanced/AudioPlayerAdvanced.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 
-interface AudioPlayerAdvancedProps {
+export interface AudioPlayerAdvancedProps {
   src: string;
 }
 

--- a/libs/react/src/components/AudioWaveformDisplay/AudioWaveformDisplay.stories.tsx
+++ b/libs/react/src/components/AudioWaveformDisplay/AudioWaveformDisplay.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import AudioWaveformDisplay, { AudioWaveformDisplayProps } from './AudioWaveformDisplay';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AudioWaveformDisplayProps> = (args) => <AudioWaveformDisplay {...args} />;
+const Template: StoryFn<AudioWaveformDisplayProps> = (args) => <AudioWaveformDisplay {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/AudioWaveformDisplay/AudioWaveformDisplay.tsx
+++ b/libs/react/src/components/AudioWaveformDisplay/AudioWaveformDisplay.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-interface AudioWaveformDisplayProps {
+export interface AudioWaveformDisplayProps {
   src: string;
 }
 

--- a/libs/react/src/components/Avatar/Avatar.stories.tsx
+++ b/libs/react/src/components/Avatar/Avatar.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import Avatar, { AvatarProps } from './Avatar';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<AvatarProps> = (args) => <Avatar {...args} />;
+const Template: StoryFn<AvatarProps> = (args) => <Avatar {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/Avatar/Avatar.tsx
+++ b/libs/react/src/components/Avatar/Avatar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AvatarProps {
+export interface AvatarProps {
   imageUrl?: string;
   altText: string;
   size?: 'small' | 'medium' | 'large';

--- a/libs/react/src/components/Badge/Badge.stories.tsx
+++ b/libs/react/src/components/Badge/Badge.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import Badge from './Badge';
+import { Meta, StoryFn } from '@storybook/react';
+import Badge, { BadgeProps } from './Badge';
 
 export default {
   title: 'component/Indicators/Badge',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => <Badge {...args} />;
+const Template: StoryFn<BadgeProps> = (args) => <Badge {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/Badge/Badge.tsx
+++ b/libs/react/src/components/Badge/Badge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface BadgeProps {
+export interface BadgeProps {
   state: 'default' | 'notification' | 'status-indicator';
   label: string;
 }

--- a/libs/react/src/components/BadgeWithCounts/BadgeWithCounts.stories.tsx
+++ b/libs/react/src/components/BadgeWithCounts/BadgeWithCounts.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import BadgeWithCounts from './BadgeWithCounts';
+import { Meta, StoryFn } from '@storybook/react';
+import BadgeWithCounts, {BadgeWithCountsProps} from './BadgeWithCounts';
 
 export default {
   title: 'component/Indicators/BadgeWithCounts',
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story = (args) => <BadgeWithCounts {...args} />;
+const Template: StoryFn<BadgeWithCountsProps> = (args) => <BadgeWithCounts {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/BadgeWithCounts/BadgeWithCounts.tsx
+++ b/libs/react/src/components/BadgeWithCounts/BadgeWithCounts.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface BadgeWithCountsProps {
+export interface BadgeWithCountsProps {
   count: number;
   maxCount?: number;
 }

--- a/libs/react/src/components/Banner/Banner.stories.tsx
+++ b/libs/react/src/components/Banner/Banner.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import Banner, { BannerProps } from './Banner';
 
 export default {
@@ -8,7 +8,7 @@ export default {
   tags: ['autodocs'],
 } as Meta;
 
-const Template: Story<BannerProps> = (args) => <Banner {...args} />;
+const Template: StoryFn<BannerProps> = (args) => <Banner {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/libs/react/src/components/Banner/Banner.tsx
+++ b/libs/react/src/components/Banner/Banner.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-interface BannerProps {
+export interface BannerProps {
   state: 'displayed' | 'hidden' | 'withCTA' | 'dismissed';
   message: string;
   ctaLabel?: string;


### PR DESCRIPTION
### Fixes: 

- Changed the BannerProps interface from private to exported to allow usage in other components and stories.
- This change enhances type safety and maintainability across the React components.
- Changed the story template type from Story to StoryFn for improved compatibility with TypeScript.
- Imported BannerProps to enhance type safety in the Banner component stories.